### PR TITLE
Upgrade dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "nyholm/psr7": "^1",
     "laminas/laminas-stdlib": "^3.16",
     "laminas/laminas-httphandlerrunner": "^2.3.0",
-    "membrane/membrane": "^0.9.2"
+    "membrane/membrane": "^0.10.0"
   },
   "require-dev": {
     "phpstan/phpstan": "^2.1.28",


### PR DESCRIPTION
Depend on latest version of Membrane.

Added PHPStan as well to check for problems with upgrade.